### PR TITLE
Adding Docker Unit Testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.2-buster
+COPY . /usr/src/myapp
+WORKDIR /usr/src/myapp
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+RUN chmod +x /usr/local/bin/composer
+RUN composer install
+ENTRYPOINT ["./vendor/phpunit/phpunit/phpunit"]

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ $span->addEvent('generated_session', [
 
 $span->end(); // pass status as an optional argument
 ```
+
+# Testing
+To make sure the tests in this repo work as you expect, you can use the included docker test wrapper:
+
+1.)  Make sure that you have docker installed
+2.)  Execute `script/dockertest` from your bash compatible shell.  You should see the test output like so
+
+TODO(JRS) : Add code coverage driver (discuss with Dmitry Krokhin if he was using this / which driver to use (xdebug?)

--- a/README.md
+++ b/README.md
@@ -49,5 +49,3 @@ To make sure the tests in this repo work as you expect, you can use the included
 
 1.)  Make sure that you have docker installed
 2.)  Execute `script/dockertest` from your bash compatible shell.  You should see the test output like so
-
-TODO(JRS) : Add code coverage driver (discuss with Dmitry Krokhin if he was using this / which driver to use (xdebug?)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "composer/xdebug-handler": "^1.3"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
-        "composer/xdebug-handler": "^1.3"
+        "php": "^7.1"
     },
     "authors": [
         {
@@ -24,6 +23,7 @@
         "classmap": ["tests"]
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5.16"
+        "phpunit/phpunit": "^7.5.16",
+        "composer/xdebug-handler": "^1.3"
     }
 }

--- a/script/dockertest
+++ b/script/dockertest
@@ -1,0 +1,3 @@
+#!/bin/bash                               
+docker build -t opentelemetry-php-unittests .
+docker run -it opentelemetry-php-unittests


### PR DESCRIPTION
I wrote a docker wrapper for performing unit tests for this repository.  
Usage can be found in the README.md

@nekufa - I wasn't sure if you were planning on using any of the code coverage drivers; when I initially pulled this down it wasn't working on my local machine but I wanted to valiate with you.  Note about that inline.

Output from the built docker container:

```
docker run -it opentelemetry-php-unittests
PHPUnit 7.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.23
Configuration: /usr/src/myapp/phpunit.xml.dist
Error:         No code coverage driver is available

.........                                                           9 / 9 (100%)

Time: 27 ms, Memory: 4.00 MB

OK (9 tests, 55 assertions)
```